### PR TITLE
US127309 Skip opt-out dialog if both hide-feedback and hide-reason are specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ The `<d2l-opt-in-flyout>` and `<d2l-opt-out-flyout>` components take in the foll
 * `hide-reason` *(Optional)* - A boolean that hides the reason field from the opt-out dialog
 * `hide-feedback` *(Optional)* - A boolean that hides the feedback textarea field from the opt-out dialog
 
+If both `hide-reason` _and_ `hide-feedback` are specified, the opt-out dialog will not display.
+
 If the `<d2l-opt-out-flyout>` has children, any `<d2l-opt-out-reason>` child elements will be used to provide the list of reasons that can be selected from the drop down for opting out. An opt-out reason with key `Other` will automatically be added and does not need to be provided. The `<d2l-opt-out-reason>` component has the following 2 required properties:
 * `key` - A key that identifies the opt-out reason. This value is passed to the `opt-out` event (see below) and is not displayed to the user. It should be the same across all languages and localizations.
 * `text` - The text that will be displayed to the user. This string *should* be localized.

--- a/demo/index.html
+++ b/demo/index.html
@@ -126,6 +126,19 @@ $_documentContainer.innerHTML = `<div class="vertical-split">
 
 document.body.appendChild($_documentContainer.content);
 </script>
+<script type="module">
+const $_documentContainer = document.createElement('template');
+
+$_documentContainer.innerHTML = `<div class="vertical-split">
+	<div class="flyout-region">
+		<d2l-opt-out-flyout hide-reason hide-feedback id="opt-out-3" open="" title="Flyout Demo Opt-out - dialog disabled" short-description="This is a <b>short</b> description" long-description="This is a <b>long</b> description" tab-position="right" tutorial-link="https://www.example.com#tutorial" help-docs-link="https://www.example.com#documentation">
+		</d2l-opt-out-flyout>
+	</div>
+	<pre id="opt-out-3-log" dir="ltr"></pre>
+</div>`;
+
+document.body.appendChild($_documentContainer.content);
+</script>
 
 		<script type="module">
 import 'd2l-typography/d2l-typography.js';
@@ -145,7 +158,7 @@ var printEvent = function(loggingElement, event) {
 	}
 };
 
-[ 'opt-in', 'opt-out', 'opt-out-2' ].forEach(function(demo) {
+[ 'opt-in', 'opt-out', 'opt-out-2', 'opt-out-3' ].forEach(function(demo) {
 	var flyout = document.getElementById(demo);
 	var log = document.getElementById(demo + '-log');
 

--- a/internal/flyout-impl.js
+++ b/internal/flyout-impl.js
@@ -367,7 +367,7 @@ class FlyoutImplementation extends mixinBehaviors(TranslateBehavior, PolymerElem
 	}
 
 	_clickOptOut() {
-		if (this.optOut) {
+		if (this.optOut && (!this.hideReason || !this.hideFeedback)) {
 			this._optOutDialogOpen = true;
 		} else {
 			this._fireEvent('opt-out');


### PR DESCRIPTION
Utilizes the existing `hide-feedback` and `hide-reason` to skip the opt-out feedback dialog when they are both specified.

This is part of PBMM work related to the product telemetry service, so we can stop PBMM clients from providing feedback.
https://rally1.rallydev.com/#/29180338367d/custom/486232622040?detail=%2Fuserstory%2F600524330916